### PR TITLE
tr7: overhaul

### DIFF
--- a/implementations/tr7/1/Dockerfile
+++ b/implementations/tr7/1/Dockerfile
@@ -9,12 +9,11 @@ ADD https://gitlab.com/jobol/tr7/-/archive/v1.0.14/tr7-v1.0.14.tar.gz tr7.tar.gz
 RUN sha256sum tr7.tar.gz && sha256sum -c checksum
 RUN mkdir tr7 && tar -C tr7 --strip-components 1 -xf tr7.tar.gz
 WORKDIR /build/tr7
-RUN make
-RUN cp tr7i /usr/local/bin/
+RUN make tr7i
+RUN install -D -t /usr/local/bin tr7i
 
 FROM debian:bookworm-slim
 COPY --from=build /usr/local/ /usr/local/
-COPY scheme-banner /usr/local/bin/
-COPY scheme-r7rs /usr/local/bin/
-RUN ldconfig
+RUN ln -s tr7i /usr/local/bin/scheme-banner \
+ && ln -s tr7i /usr/local/bin/scheme-r7rs
 CMD ["scheme-banner"]

--- a/implementations/tr7/1/scheme-banner
+++ b/implementations/tr7/1/scheme-banner
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -eu
-exec tr7i "$@"

--- a/implementations/tr7/1/scheme-r7rs
+++ b/implementations/tr7/1/scheme-r7rs
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec tr7i "$@"

--- a/implementations/tr7/head/Dockerfile
+++ b/implementations/tr7/head/Dockerfile
@@ -6,13 +6,12 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 WORKDIR /build
 RUN git clone https://gitlab.com/jobol/tr7.git --depth=1
 WORKDIR /build/tr7
-RUN make
-RUN cp tr7i /usr/local/bin/
+RUN make tr7i
+#RUN make test
+RUN make install
 
 FROM debian:bookworm-slim
 COPY --from=build /usr/local/ /usr/local/
-COPY scheme-banner /usr/local/bin/
-COPY scheme-r7rs /usr/local/bin/
-RUN ldconfig
-ENV TR7_LIB_PATH=/build/tr7/tr7libs
+RUN ln -s tr7i /usr/local/bin/scheme-banner \
+ && ln -s tr7i /usr/local/bin/scheme-r7rs
 CMD ["scheme-banner"]

--- a/implementations/tr7/head/scheme-banner
+++ b/implementations/tr7/head/scheme-banner
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -eu
-exec tr7i "$@"

--- a/implementations/tr7/head/scheme-r7rs
+++ b/implementations/tr7/head/scheme-r7rs
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec tr7i "$@"


### PR DESCRIPTION
- Use symbolic links for scheme-banner and scheme-r7rs.

- Use upstream `make tr7i`.

- Omit ldconfig. It is not needed for most containers.

- Omit TR7_LIB_PATH. The upstream head Makefile takes care of it.

The version 1 container currently does not install tr7libs. Upstream support for installation is underdeveloped in 1.0.14. It is easier to wait for the next 1.x release than to provide a workaround.