### PR TITLE
Added small script to build all heads

### DIFF
--- a/build-heads.sh
+++ b/build-heads.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+implementations=$(find ./implementations -maxdepth 1 -name "*")
+
+for path in $implementations
+do
+    name=$(basename ${path})
+    if [ -d ${path}/head ]
+    then
+        echo ${path}
+        docker build ${path}/head --tag=schemers/${name}:head
+    fi
+done

--- a/build-heads.sh
+++ b/build-heads.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+build_only="${1}"
 implementations=$(find ./implementations -maxdepth 1 -name "*")
 
 for path in $implementations
@@ -7,7 +8,9 @@ do
     name=$(basename ${path})
     if [ -d ${path}/head ]
     then
-        echo ${path}
-        docker build ${path}/head --tag=schemers/${name}:head
+        if [ "${build_only}" == "" -o "${build_only}" == "${name}" ]
+        then
+            docker build ${path}/head --tag=schemers/${name}:head
+        fi
     fi
 done

--- a/build-heads.sh
+++ b/build-heads.sh
@@ -7,14 +7,11 @@ cd "$(dirname "$0")"
 
 implementations=$(find ./implementations -maxdepth 1 -name "*")
 
-for path in $implementations
-do
+for path in $implementations; do
     name=$(basename "${path}")
-    if [ -d "${path}/head" ]
-    then
-        if [ "${build_only}" == "" -o "${build_only}" == "${name}" ]
-        then
-            docker build "${path}/head" --tag=schemers/${name}:head
+    if [ -d "${path}/head" ]; then
+        if [ "${build_only}" = "" ] || [ "${build_only}" = "${name}" ]; then
+            docker build "${path}/head" --tag="schemers/${name}:head"
         fi
     fi
 done

--- a/build-heads.sh
+++ b/build-heads.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 
-build_only="${1}"
+set -eu
+
+build_only="${1:-}"
+cd "$(dirname "$0")"
+
 implementations=$(find ./implementations -maxdepth 1 -name "*")
 
 for path in $implementations
 do
-    name=$(basename ${path})
-    if [ -d ${path}/head ]
+    name=$(basename "${path}")
+    if [ -d "${path}/head" ]
     then
         if [ "${build_only}" == "" -o "${build_only}" == "${name}" ]
         then
-            docker build ${path}/head --tag=schemers/${name}:head
+            docker build "${path}/head" --tag=schemers/${name}:head
         fi
     fi
 done


### PR DESCRIPTION
Added a small script to build all heads or just certain implementations. This is one small step towards build automation. It's also handy in a situation where one considers opening an issue about something on the implementations bugtracker. But can run use the git version to see if the bug is already fixed in there.