### PR TITLE
Use the git head as latest as it works much better.

### DIFF
--- a/implementations/foment/0/Dockerfile
+++ b/implementations/foment/0/Dockerfile
@@ -1,13 +1,15 @@
 # -*- mode: dockerfile; coding: utf-8 -*-
 FROM debian:bookworm-slim AS build
 RUN apt-get update && apt-get -y --no-install-recommends install \
-      build-essential \
+      build-essential git ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /build
 COPY checksum checksum
-ADD https://github.com/leftmike/foment/archive/v0.4.1.tar.gz foment.tar.gz
-RUN sha256sum foment.tar.gz && sha256sum -c checksum
-RUN mkdir foment && tar -C foment --strip-components 1 -xf foment.tar.gz
+#ADD https://github.com/leftmike/foment/archive/v0.4.1.tar.gz foment.tar.gz
+#RUN sha256sum foment.tar.gz && sha256sum -c checksum
+#RUN mkdir foment && tar -C foment --strip-components 1 -xf foment.tar.gz
+# Use the git head as the latest release is not in good shape but head is
+RUN git clone https://github.com/leftmike/foment.git
 WORKDIR /build/foment/unix
 RUN make
 


### PR DESCRIPTION
The implementation development seems to go on, so switching to release when the next one comes.