### PR TITLE
refactor: update link to codeberg for Capy

### DIFF
--- a/implementations/capyscheme/head/Dockerfile
+++ b/implementations/capyscheme/head/Dockerfile
@@ -6,9 +6,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
   wget \
   xz-utils \
   make \
-  libffi-dev \
   build-essential \
-  clang \
   rsync \
   && rm -rf /var/lib/apt/lists/*
 RUN if [ "$(uname --machine)" = "aarch64" ]; then wget -O rust.tar.xz https://static.rust-lang.org/dist/rust-nightly-aarch64-unknown-linux-gnu.tar.xz; fi
@@ -19,10 +17,8 @@ RUN git clone https://codeberg.org/playXE/capy.git --depth=1
 WORKDIR /build/capy
 RUN make COMPILE_PSYNTAX=1 PREFIX=/usr/local build
 RUN make PREFIX=/usr/local install
-
 FROM debian:trixie-slim
 COPY --from=build /usr/local/ /usr/local/
-RUN apt-get update && apt-get install -y lld
 ENV PATH=/usr/local/capy/0.1.0:${PATH}
 COPY scheme-banner /usr/local/bin/
 CMD scheme-banner

--- a/implementations/capyscheme/head/Dockerfile
+++ b/implementations/capyscheme/head/Dockerfile
@@ -15,10 +15,10 @@ RUN if [ "$(uname --machine)" = "aarch64" ]; then wget -O rust.tar.xz https://st
 RUN if [ "$(uname --machine)" = "x86_64" ]; then wget -O rust.tar.xz https://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.xz; fi
 RUN mkdir rust && tar -C rust --strip-components 1 -xf rust.tar.xz && cd rust && bash install.sh
 WORKDIR /build
-RUN git clone https://github.com/playX18/capyscheme.git --depth=1
-WORKDIR /build/capyscheme
+RUN git clone https://codeberg.org/playXE/capy.git --depth=1
+WORKDIR /build/capy
 RUN make COMPILE_PSYNTAX=1 PREFIX=/usr/local build
-RUN make COMPILE_PSYNTAX=1 PREFIX=/usr/local install
+RUN make PREFIX=/usr/local install
 
 FROM debian:trixie-slim
 COPY --from=build /usr/local/ /usr/local/


### PR DESCRIPTION
Capy has moved to Codeberg, GH repo is just a mirror now. Updated the link and also removed dependencies that are not required. `libffi` is not required because libffi-sys is built from source entirely and then linked into runtime. 