### PR TITLE
New workflow template, simplifications

### DIFF
--- a/.github/workflows/chibi.yml
+++ b/.github/workflows/chibi.yml
@@ -6,138 +6,28 @@ on:
     paths:
       - implementations/chibi/**/Dockerfile*
       - .github/workflows/chibi*.yml
-  schedule:
-    - cron: "17 4 * * 2"
 jobs:
-  build-debian:
+  latest:
     strategy:
       fail-fast: false
       matrix:
+        version: [latest]
         os: [ubuntu-24.04, ubuntu-24.04-arm]
+        linux: [debian, alpine]
     runs-on: ${{ matrix.os }}
-    if: github.ref != 'refs/heads/master'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Build schemers/chibi latest
-        run: make VERSION=latest SCHEME=chibi build
-  build-debian-head:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Build schemers/chibi head
-        run: make VERSION=head SCHEME=chibi build
-  build-alpine:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Build schemers/chibi latest alpine
-        run: make LINUX=alpine VERSION=latest SCHEME=chibi build
-  build-alpine-head:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Build schemers/chibi head alpine
-        run: make LINUX=alpine VERSION=head SCHEME=chibi build
-  push-debian:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Build chibi
+        run: make VERSION=${{ matrix.version }} SCHEME=chibi LINUX=${{ matrix.linux }} build
       - name: Login to DockerHub
+        if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build schemers/chibi latest
-        run: make VERSION=latest SCHEME=chibi build push
-  push-debian-head:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build schemers/chibi head
-        run: make VERSION=head SCHEME=chibi build push
-  push-alpine:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build schemers/chibi latest alpine
-        run: make LINUX=alpine VERSION=latest SCHEME=chibi build push
-  push-alpine-head:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build schemers/chibi head alpine
-        run: make LINUX=alpine VERSION=head SCHEME=chibi build push
+      - name: Push chibi
+        if: github.ref == 'refs/heads/master'
+        run: make VERSION=${{ matrix.version }} SCHEME=chibi LINUX=${{ matrix.linux }} build push

--- a/.github/workflows/chibi.yml
+++ b/.github/workflows/chibi.yml
@@ -19,15 +19,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
       - name: Build chibi
         run: make VERSION=${{ matrix.version }} SCHEME=chibi LINUX=${{ matrix.linux }} build
       - name: Login to DockerHub
         if: github.ref == 'refs/heads/master'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push chibi
         if: github.ref == 'refs/heads/master'
-        run: make VERSION=${{ matrix.version }} SCHEME=chibi LINUX=${{ matrix.linux }} build push
+        run: make VERSION=${{ matrix.version }} SCHEME=chibi LINUX=${{ matrix.linux }} push

--- a/.github/workflows/weekly-heads.yml
+++ b/.github/workflows/weekly-heads.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
       - name: Build ${{ matrix.scheme }}
         run: make VERSION=latest SCHEME=${{ matrix.scheme }} LINUX=${{ matrix.linux }} build
       - name: Login to DockerHub
         if: github.ref == 'refs/heads/master'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/weekly-heads.yml
+++ b/.github/workflows/weekly-heads.yml
@@ -1,33 +1,35 @@
-name: chibi
+name: Weekly heads
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "17 4 * * 2"
   push:
     paths:
-      - implementations/chibi/**/Dockerfile*
-      - .github/workflows/chibi*.yml
+      - .github/workflows/weekly-heads.yml
 jobs:
-  latest:
+  heads:
     strategy:
       fail-fast: false
       matrix:
+        scheme: [chibi, tr7]
+        version: [head]
         linux: [debian, alpine]
         os: [ubuntu-24.04, ubuntu-24.04-arm]
-        version: [latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Build chibi
-        run: make VERSION=${{ matrix.version }} SCHEME=chibi LINUX=${{ matrix.linux }} build
+      - name: Build ${{ matrix.scheme }}
+        run: make VERSION=latest SCHEME=${{ matrix.scheme }} LINUX=${{ matrix.linux }} build
       - name: Login to DockerHub
         if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Push chibi
+      - name: Build ${{ matrix.scheme }}
         if: github.ref == 'refs/heads/master'
-        run: make VERSION=${{ matrix.version }} SCHEME=chibi LINUX=${{ matrix.linux }} build push
+        run: make VERSION=${{ matrix.version }} SCHEME=${{ matrix.scheme }} LINUX=${{ matrix.linux }} push

--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,12 @@ clean-image:
 	@echo "CLEAN_CMD : ${CLEAN_CMD}"
 	${IMAGE_CLEAN_CMD}
 
+WORKFLOW_OS=$(shell cat implementations/${SCHEME}/WORKFLOW_OS.txt || echo "ubuntu-24.04, ubuntu-24.04-arm")
+WORKFLOW_LINUX=$(shell cat implementations/${SCHEME}/WORKFLOW_LINUX.txt || echo "debian, alpine")
 workflow:
 	rm -rf .github/workflows/${SCHEME}-push-action.yml
-	sed 's/\$${SCHEME}/${SCHEME}/g' workflow-template.yml > .github/workflows/${SCHEME}.yml
-
-workflow-head: workflow
-	# Add scheduled builds
-	sed -i '8 a \ \ schedule:\n\ \ \ \ - cron: "17 4 * * 2"' .github/workflows/${SCHEME}.yml
+	cp workflow-template.yml .github/workflows/${SCHEME}.yml
+	sed -i 's/\$${SCHEME}/${SCHEME}/g' .github/workflows/${SCHEME}.yml
+	sed -i 's/\$${WORKFLOW_OS}/${WORKFLOW_OS}/g' .github/workflows/${SCHEME}.yml
+	sed -i 's/\$${WORKFLOW_LINUX}/${WORKFLOW_LINUX}/g' .github/workflows/${SCHEME}.yml
 

--- a/README.md
+++ b/README.md
@@ -53,19 +53,16 @@ Examples:
     > BUILD_CMD: docker build . -f Dockerfile --tag=schemers/chibi:head
     > PUSH_CMD : docker push schemers/chibi:head
 
-## Updating workflow
+## Workflow
 
-If you need to update workflows change workflow-template.yml and then update
-them using make.
+If you need to update workflows change workflow-template.yml if needed
+and then update them using make. To override default workflow build operating
+systems and linuxes use following files.
 
-For implementations that are not under active development and do not need
-weekly push of head
+- implementation/$SCHEME/WORKFLOW_OS.txt
+    - If does not exist defaults to "ubuntu-24.04, ubuntu-24.04-arm"
+- implementation/$SCHEME/WORKFLOW_LINUX.txt
+    - If does not exist defaults to "debian, alpine"
 
     make SCHEME=chibi workflow
-
-for ones that do
-
-    make SCHEME=chibi workflow-head
-
-
 

--- a/workflow-template.yml
+++ b/workflow-template.yml
@@ -7,135 +7,27 @@ on:
       - implementations/${SCHEME}/**/Dockerfile*
       - .github/workflows/${SCHEME}*.yml
 jobs:
-  build-debian:
+  latest:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        linux: [${WORKFLOW_LINUX}]
+        os: [${WORKFLOW_OS}]
+        version: [latest]
     runs-on: ${{ matrix.os }}
-    if: github.ref != 'refs/heads/master'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Build schemers/${SCHEME} latest
-        run: make VERSION=latest SCHEME=${SCHEME} build
-  build-debian-head:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Build schemers/${SCHEME} head
-        run: make VERSION=head SCHEME=${SCHEME} build
-  build-alpine:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Build schemers/${SCHEME} latest alpine
-        run: make LINUX=alpine VERSION=latest SCHEME=${SCHEME} build
-  build-alpine-head:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Build schemers/${SCHEME} head alpine
-        run: make LINUX=alpine VERSION=head SCHEME=${SCHEME} build
-  push-debian:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
+      - name: Build ${SCHEME}
+        run: make VERSION=${{ matrix.version }} SCHEME=${SCHEME} LINUX=${{ matrix.linux }} build
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/master'
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build schemers/${SCHEME} latest
-        run: make VERSION=latest SCHEME=${SCHEME} build push
-  push-debian-head:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build schemers/${SCHEME} head
-        run: make VERSION=head SCHEME=${SCHEME} build push
-  push-alpine:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build schemers/${SCHEME} latest alpine
-        run: make LINUX=alpine VERSION=latest SCHEME=${SCHEME} build push
-  push-alpine-head:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build schemers/${SCHEME} head alpine
-        run: make LINUX=alpine VERSION=head SCHEME=${SCHEME} build push
+      - name: Push ${SCHEME}
+        if: github.ref == 'refs/heads/master'
+        run: make VERSION=${{ matrix.version }} SCHEME=${SCHEME} LINUX=${{ matrix.linux }} push


### PR DESCRIPTION
- Simplify the workflow-template
  - Write more value to it when running the make job
- Update chibi to new workflow from that template
- Allow implementations specific override of build osses and linuxes trough implementations/$SCHEME/WORKFLOW_OS.txt and implementations/$SCHEME/WORKFLOW_LINUX.txt
- Move weekly building of heads to it's own workflow file
- Add chibi and tr7 to weekly head builds as first test implementations as they build fast